### PR TITLE
FIX: skip signal handler registration when building java package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ cmake_dependent_option(ENABLE_TESTCOVERAGE "Enable compilation with test coverag
 option(BUILD_EXTENSION_PATH "Path to extension to build" "")
 option(BUILD_CYTHON_MODULES "Build cython modules." OFF)
 option(LOG_FATAL_THROW "Log exceptions but do not abort" ON)
+option(BUILD_JAVA_NATIVE "Skip signal handler registration for Java Binding" OFF)
 cmake_dependent_option(USE_SPLIT_ARCH_DLL "Build a separate DLL for each Cuda arch (Windows only)." ON "MSVC" OFF)
 cmake_dependent_option(USE_CCACHE "Attempt using CCache to wrap the compilation" ON "UNIX" OFF)
 cmake_dependent_option(MXNET_FORCE_SHARED_CRT "Build with dynamic CRT on Windows (/MD)" ON "MXNET_BUILD_SHARED_LIBS" OFF)
@@ -968,6 +969,10 @@ endif()
 if(USE_CPP_PACKAGE)
   add_subdirectory(cpp-package)
   target_compile_definitions(mxnet PUBLIC MXNET_USE_CPP_PACKAGE=1)
+endif()
+
+if(BUILD_JAVA_NATIVE)
+  add_definitions(-DSKIP_SIGNAL_HANDLER_REGISTRATION=1)
 endif()
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Distribution")

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -310,13 +310,8 @@ build_ubuntu_cpu() {
     build_ubuntu_cpu_openblas
 }
 
-build_ubuntu_cpu_and_test() {
-    build_ubuntu_cpu
-    java_package_integration_test
-}
-
-build_ubuntu_gpu_and_test() {
-    build_ubuntu_gpu
+build_ubuntu_cpu_and_test_java() {
+    build_ubuntu_cpu_openblas_java
     java_package_integration_test
 }
 
@@ -345,6 +340,24 @@ build_ubuntu_cpu_openblas() {
         -DUSE_DIST_KVSTORE=ON \
         -DBUILD_CYTHON_MODULES=ON \
         -DBUILD_EXTENSION_PATH=/work/mxnet/example/extensions/lib_external_ops \
+        -G Ninja /work/mxnet
+    ninja
+}
+
+build_ubuntu_cpu_openblas_java() {
+    set -ex
+    cd /work/build
+    CXXFLAGS="-Wno-error=strict-overflow" CC=gcc-7 CXX=g++-7 cmake \
+        -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
+        -DENABLE_TESTCOVERAGE=ON \
+        -DUSE_TVM_OP=ON \
+        -DUSE_BLAS=Open \
+        -DUSE_ONEDNN=OFF \
+        -DUSE_CUDA=OFF \
+        -DUSE_DIST_KVSTORE=ON \
+        -DBUILD_CYTHON_MODULES=ON \
+        -DBUILD_EXTENSION_PATH=/work/mxnet/example/extensions/lib_external_ops \
+        -DBUILD_JAVA_NATIVE=ON \
         -G Ninja /work/mxnet
     ninja
 }

--- a/src/initialize.cc
+++ b/src/initialize.cc
@@ -348,8 +348,6 @@ static inline void printStackTrace(FILE *out = stderr,
 #endif
 }
 
-#define SKIP_SIGNAL_HANDLER_REGISTRATION 1
-
 #define SIGNAL_HANDLER(SIGNAL, HANDLER_NAME, IS_FATAL)               \
 std::shared_ptr<void(int)> HANDLER_NAME(                             \
   signal(SIGNAL, [](int signum) {                                    \
@@ -378,7 +376,7 @@ std::shared_ptr<void(int)> HANDLER_NAME(                             \
   [](auto f) { signal(SIGNAL, f); });
 
 // TODO(cspchen): avoid jvm exit with code 139. By now, we just skip it
-#if SKIP_SIGNAL_HANDLER_REGISTRATION
+#if !SKIP_SIGNAL_HANDLER_REGISTRATION
 SIGNAL_HANDLER(SIGSEGV, SIGSEGVHandler, true);
 SIGNAL_HANDLER(SIGFPE, SIGFPEHandler, false);
 SIGNAL_HANDLER(SIGBUS, SIGBUSHandler, false);


### PR DESCRIPTION
## Description ##
Add option when build mxnet for java package

## Checklist ##
### Essentials ###
- Skip signal handler registration when we build mxnet as java native lib

### Changes ###
- CMakeList.txt add option BUILD_JAVA_NATIVE
- add definition SKIP_SIGNAL_HANDLER_REGISTRATION=1
- ci/docker/runtime_functions.sh add BUILD_JAVA_NATIVE=ON

## Comments ##
- None
